### PR TITLE
Small change

### DIFF
--- a/01-category-theory.tex
+++ b/01-category-theory.tex
@@ -281,6 +281,7 @@ In some cases, we leave $x$ implicit and simply say that $\Fscr$ is \emph{repres
 \begin{example}
   Consider the \emph{forgetful functor} $\CRing \to \Set$ which sends a ring $A$ to its underlying set and a morphism to the underlying function.
   This functor is representable by the commutative ring $\Zbb[X]$ and the representing element is $X \in \mathbb{Z}[X]$.
+  Here $\Zbb[X]$ denotes the polynomial ring in one variable $X$ over $\Zbb$.
   \exer{Add details.}
 \end{example}
 

--- a/01-category-theory.tex
+++ b/01-category-theory.tex
@@ -280,7 +280,8 @@ In some cases, we leave $x$ implicit and simply say that $\Fscr$ is \emph{repres
 
 \begin{example}
   Consider the \emph{forgetful functor} $\CRing \to \Set$ which sends a ring $A$ to its underlying set and a morphism to the underlying function.
-  \exer{This functor is representable.}
+  This functor is representable by the commutative ring $\Zbb[X]$ and the representing element is $X \in \mathbb{Z}[X]$.
+  \exer{Add details.}
 \end{example}
 
 \begin{example}


### PR DESCRIPTION
This adds some details about representability of the forgetful functor from `CRing` to `Set`.